### PR TITLE
golang-http-demo to 0.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,6 +7,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.82
+- name: golang-http-demo
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.4
 - name: python-hg-deploy
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.2


### PR DESCRIPTION
Promote golang-http-demo to version 0.0.4